### PR TITLE
little_bigtable: add additionals fns to avoid panic

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         imgtag:
-          - "golang:1.17-bullseye"
+          - "golang:1.18-bullseye"
         goarch:
           - "amd64"
 

--- a/bttest/inmem.go
+++ b/bttest/inmem.go
@@ -19,6 +19,7 @@ Package bttest contains test helpers for working with the bigtable package.
 
 To use a Server, create it, and then connect to it with no security:
 (The project/instance values are ignored.)
+
 	srv, err := bttest.NewServer("localhost:0")
 	...
 	conn, err := grpc.Dial(srv.Addr, grpc.WithInsecure())
@@ -46,6 +47,7 @@ import (
 	"sync"
 	"time"
 
+	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	emptypb "github.com/golang/protobuf/ptypes/empty"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/btree"
@@ -205,6 +207,10 @@ func (s *server) GetTable(ctx context.Context, req *btapb.GetTableRequest) (*bta
 	}, nil
 }
 
+func (s *server) UpdateTable(context.Context, *btapb.UpdateTableRequest) (*longrunningpb.Operation, error) {
+	return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support table updates")
+}
+
 func (s *server) DeleteTable(ctx context.Context, req *btapb.DeleteTableRequest) (*emptypb.Empty, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -216,6 +222,10 @@ func (s *server) DeleteTable(ctx context.Context, req *btapb.DeleteTableRequest)
 		delete(s.tables, req.Name)
 	}
 	return &emptypb.Empty{}, nil
+}
+
+func (s *server) UndeleteTable(context.Context, *btapb.UndeleteTableRequest) (*longrunningpb.Operation, error) {
+	return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support table undeletes")
 }
 
 func (s *server) ModifyColumnFamilies(ctx context.Context, req *btapb.ModifyColumnFamiliesRequest) (*btapb.Table, error) {
@@ -352,6 +362,30 @@ func (s *server) ListSnapshots(context.Context, *btapb.ListSnapshotsRequest) (*b
 
 func (s *server) DeleteSnapshot(context.Context, *btapb.DeleteSnapshotRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support snapshots")
+}
+
+func (s *server) CreateBackup(context.Context, *btapb.CreateBackupRequest) (*longrunning.Operation, error) {
+	return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support backups")
+}
+
+func (s *server) GetBackup(context.Context, *btapb.GetBackupRequest) (*btapb.Backup, error) {
+	return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support backups")
+}
+
+func (s *server) UpdateBackup(context.Context, *btapb.UpdateBackupRequest) (*btapb.Backup, error) {
+	return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support backups")
+}
+
+func (s *server) DeleteBackup(context.Context, *btapb.DeleteBackupRequest) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support backups")
+}
+
+func (s *server) ListBackups(context.Context, *btapb.ListBackupsRequest) (*btapb.ListBackupsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support backups")
+}
+
+func (s *server) RestoreTable(context.Context, *btapb.RestoreTableRequest) (*longrunningpb.Operation, error) {
+	return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support restores")
 }
 
 func (s *server) ReadRows(req *btpb.ReadRowsRequest, stream btpb.Bigtable_ReadRowsServer) error {

--- a/bttest/instance_server.go
+++ b/bttest/instance_server.go
@@ -96,6 +96,10 @@ func (s *server) UpdateCluster(ctx context.Context, req *btapb.Cluster) (*longru
 	return nil, errUnimplemented
 }
 
+func (s *server) PartialUpdateCluster(ctx context.Context, req *btapb.PartialUpdateClusterRequest) (*longrunning.Operation, error) {
+	return nil, errUnimplemented
+}
+
 func (s *server) DeleteCluster(ctx context.Context, req *btapb.DeleteClusterRequest) (*empty.Empty, error) {
 	return nil, errUnimplemented
 }
@@ -129,5 +133,9 @@ func (s *server) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyReques
 }
 
 func (s *server) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
+	return nil, errUnimplemented
+}
+
+func (s *server) ListHotTablets(ctx context.Context, req *btapb.ListHotTabletsRequest) (*btapb.ListHotTabletsResponse, error) {
 	return nil, errUnimplemented
 }


### PR DESCRIPTION
This removes a panic if backup endpoints are called

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x80 pc=0x822f34]

goroutine 8 [running]:
github.com/bitly/little_bigtable/bttest.(*server).ListBackups(0xc000080cc0, {0x9d82a0, 0xc00007a4e0}, 0xc00004ec00)
	<autogenerated>:1 +0x34
google.golang.org/genproto/googleapis/bigtable/admin/v2._BigtableTableAdmin_ListBackups_Handler({0x925f80, 0xc000080cc0}, {0x9d82a0, 0xc00007a4e0}, 0xc00006e540, 0x0)
	/data/go_mod_cache/google.golang.org/genproto@v0.0.0-20210927142257-433400c27d05/googleapis/bigtable/admin/v2/bigtable_table_admin.pb.go:4358 +0x173
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00016ba40, {0x9e0920, 0xc000210000}, 0xc000240000, 0xc000155c80, 0xefe338, 0x0)
	/data/go_mod_cache/google.golang.org/grpc@v1.41.0/server.go:1279 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc00016ba40, {0x9e0920, 0xc000210000}, 0xc000240000, 0x0)
	/data/go_mod_cache/google.golang.org/grpc@v1.41.0/server.go:1608 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/data/go_mod_cache/google.golang.org/grpc@v1.41.0/server.go:923 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/data/go_mod_cache/google.golang.org/grpc@v1.41.0/server.go:921 +0x294
```