### PR TITLE
Add automated backup configs to emulator tables

### DIFF
--- a/bttest/inmem.go
+++ b/bttest/inmem.go
@@ -58,6 +58,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 	"rsc.io/binaryregexp"
 )
 
@@ -120,6 +121,10 @@ func NewServer(laddr string, db *sql.DB, opt ...grpc.ServerOption) (*Server, err
 			tableBackend: NewSqlTables(db),
 		},
 	}
+	opsServer := &operationsServer{
+		operations: make(map[string]*longrunningpb.Operation),
+	}
+	longrunningpb.RegisterOperationsServer(s.srv, opsServer)
 	s.s.LoadTables()
 	btapb.RegisterBigtableInstanceAdminServer(s.srv, s.s)
 	btapb.RegisterBigtableTableAdminServer(s.srv, s.s)
@@ -162,9 +167,10 @@ func (s *server) CreateTable(ctx context.Context, req *btapb.CreateTableRequest)
 	s.mu.Unlock()
 
 	ct := &btapb.Table{
-		Name:           tbl,
-		ColumnFamilies: req.GetTable().GetColumnFamilies(),
-		Granularity:    req.GetTable().GetGranularity(),
+		Name:                  tbl,
+		ColumnFamilies:        req.GetTable().GetColumnFamilies(),
+		Granularity:           req.GetTable().GetGranularity(),
+		AutomatedBackupConfig: req.GetTable().GetAutomatedBackupConfig(),
 	}
 	if ct.Granularity == 0 {
 		ct.Granularity = btapb.Table_MILLIS
@@ -202,13 +208,42 @@ func (s *server) GetTable(ctx context.Context, req *btapb.GetTableRequest) (*bta
 	}
 
 	return &btapb.Table{
-		Name:           tbl,
-		ColumnFamilies: toColumnFamilies(tblIns.columnFamilies()),
+		Name:                  tbl,
+		ColumnFamilies:        toColumnFamilies(tblIns.columnFamilies()),
+		AutomatedBackupConfig: getAutomatedBackupConfig(tblIns.backupPolicy),
 	}, nil
 }
 
-func (s *server) UpdateTable(context.Context, *btapb.UpdateTableRequest) (*longrunningpb.Operation, error) {
-	return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support table updates")
+func (s *server) UpdateTable(ctx context.Context, req *btapb.UpdateTableRequest) (*longrunningpb.Operation, error) {
+	if req.UpdateMask.GetPaths() == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "update mask is required")
+	}
+	for _, path := range req.UpdateMask.GetPaths() {
+		if !strings.HasPrefix(path, "automated_backup_policy.") {
+			return nil, status.Errorf(codes.Unimplemented, "the emulator does not currently support updates other than automated_backup_policy")
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tables[req.Table.Name].backupPolicy = getAutomatedBackupPolicy(req.Table)
+	ct := &btapb.Table{
+		Name:                  req.Table.Name,
+		ColumnFamilies:        req.GetTable().GetColumnFamilies(),
+		AutomatedBackupConfig: req.GetTable().GetAutomatedBackupConfig(),
+	}
+
+	respAny, err := anypb.New(ct)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to wrap result: %v", err)
+	}
+	op := &longrunningpb.Operation{
+		Name:   fmt.Sprintf("operations/op-%d", time.Now().UnixNano()),
+		Done:   true,
+		Result: &longrunningpb.Operation_Response{Response: respAny},
+	}
+
+	return op, nil
 }
 
 func (s *server) DeleteTable(ctx context.Context, req *btapb.DeleteTableRequest) (*emptypb.Empty, error) {
@@ -273,9 +308,10 @@ func (s *server) ModifyColumnFamilies(ctx context.Context, req *btapb.ModifyColu
 	s.tableBackend.Save(tbl)
 
 	return &btapb.Table{
-		Name:           req.Name,
-		ColumnFamilies: toColumnFamilies(tbl.families),
-		Granularity:    btapb.Table_TimestampGranularity(btapb.Table_MILLIS),
+		Name:                  req.Name,
+		ColumnFamilies:        toColumnFamilies(tbl.families),
+		Granularity:           btapb.Table_TimestampGranularity(btapb.Table_MILLIS),
+		AutomatedBackupConfig: getAutomatedBackupConfig(tbl.backupPolicy),
 	}, nil
 }
 
@@ -1256,12 +1292,13 @@ func (s *server) SampleRowKeys(req *btpb.SampleRowKeysRequest, stream btpb.Bigta
 }
 
 type table struct {
-	parent   string
-	tableId  string
-	mu       sync.RWMutex
-	counter  uint64                   // increment by 1 when a new family is created
-	families map[string]*columnFamily // keyed by plain family name
-	rows     *SqlRows                 // indexed by row key
+	parent       string
+	tableId      string
+	mu           sync.RWMutex
+	counter      uint64                   // increment by 1 when a new family is created
+	families     map[string]*columnFamily // keyed by plain family name
+	rows         *SqlRows                 // indexed by row key
+	backupPolicy *btapb.Table_AutomatedBackupPolicy
 }
 
 const btreeDegree = 16
@@ -1280,11 +1317,12 @@ func newTable(ctr *btapb.CreateTableRequest, db *sql.DB) *table {
 		}
 	}
 	return &table{
-		parent:   ctr.Parent,
-		tableId:  ctr.TableId,
-		families: fams,
-		counter:  c,
-		rows:     NewSqlRows(db, ctr.Parent, ctr.TableId),
+		parent:       ctr.Parent,
+		tableId:      ctr.TableId,
+		families:     fams,
+		counter:      c,
+		rows:         NewSqlRows(db, ctr.Parent, ctr.TableId),
+		backupPolicy: getAutomatedBackupPolicy(ctr.Table),
 	}
 }
 
@@ -1566,4 +1604,22 @@ func toColumnFamilies(families map[string]*columnFamily) map[string]*btapb.Colum
 		fs[k] = v.proto()
 	}
 	return fs
+}
+
+func getAutomatedBackupConfig(policy *btapb.Table_AutomatedBackupPolicy) *btapb.Table_AutomatedBackupPolicy_ {
+	if policy == nil {
+		return nil
+	}
+	return &btapb.Table_AutomatedBackupPolicy_{
+		AutomatedBackupPolicy: policy,
+	}
+}
+
+func getAutomatedBackupPolicy(bTable *btapb.Table) *btapb.Table_AutomatedBackupPolicy {
+	if bTable != nil && bTable.AutomatedBackupConfig != nil {
+		if policy, ok := bTable.AutomatedBackupConfig.(*btapb.Table_AutomatedBackupPolicy_); ok {
+			return policy.AutomatedBackupPolicy
+		}
+	}
+	return nil
 }

--- a/bttest/operations.go
+++ b/bttest/operations.go
@@ -1,0 +1,26 @@
+package bttest
+
+import (
+	"context"
+	"sync"
+
+	"cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type operationsServer struct {
+	longrunningpb.UnimplementedOperationsServer
+	operations map[string]*longrunningpb.Operation
+	mu         sync.RWMutex
+}
+
+func (s *operationsServer) GetOperation(ctx context.Context, req *longrunningpb.GetOperationRequest) (*longrunningpb.Operation, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	op, ok := s.operations[req.Name]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "operation %q not found", req.Name)
+	}
+	return op, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,10 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/stretchr/testify v1.10.0
+	google.golang.org/genproto v0.0.0-20250106144421-5f5ef82da422
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250106144421-5f5ef82da422
 	google.golang.org/grpc v1.69.4
+	google.golang.org/protobuf v1.36.2
 	rsc.io/binaryregexp v0.2.0
 )
 
@@ -55,8 +57,6 @@ require (
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/api v0.216.0 // indirect
-	google.golang.org/genproto v0.0.0-20250106144421-5f5ef82da422 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 // indirect
-	google.golang.org/protobuf v1.36.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Part of [AW-233](https://puffer.atlassian.net/browse/AW-233)

## PR

1. Adds automated backup configs to the emulator, this allows us to test this addition to the bigtablesync package in bitly/bitly and run in dev ([corresponding PR here)](https://github.com/bitly/bitly/pull/48307))
2. Implements the UpdateTable function only for updates to `automated_backup_policy`. This is for the same reason^


## Bug (resolved with #23 ):

I'm not sure if this is just for me, or just locally, but when building and running little_bigtable from its master branch on my VM I was seeing the following errors autodowning the service on startup:

```bash
sql_tables.go:81: sql: Scan error on column index 2, name "metadata": gob: name not registered for interface: "*admin.GcRule_MaxNumVersions"
```

I went back and traced this issue to [this commit](https://github.com/bitly/little_bigtable/commit/fada1c42d7a9e2650a61b7cbda9b6258e6bc2bca), relating to the migration to the new packages there.

It seems like:
1. This is only an issue with old data already registered with gob ( i know nothing about gob just going on initial thoughts)
2. So, if you just remove your db file and run it would be fine - and should maybe be fine on testrunners for that reason?
3. But, if you want to retain the old data in the emulator, I needed to use this workaround.

[These lines in this PR ](https://github.com/zoemccormick/little_bigtable/blob/9d9b17d2b76c944a61037f74f741104ea788c2fb/bttest/inmem.go#L1506-L1509) were a workaround for those errors for me. I would love thoughts on this @jehiah - I can remove these from the PR if theyre not needed in general but I wasn't sure if others would have this problem if we update little_bigtable.


[AW-233]: https://puffer.atlassian.net/browse/AW-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ