### PR TITLE
fix compatibility issue with gob registrations

### DIFF
--- a/bttest/inmem.go
+++ b/bttest/inmem.go
@@ -1464,10 +1464,12 @@ func (r *row) String() string {
 var gcTypeWarn sync.Once
 
 func init() {
-	gob.Register(&btapb.GcRule_Intersection_{})
-	gob.Register(&btapb.GcRule_Union_{})
-	gob.Register(&btapb.GcRule_MaxAge{})
-	gob.Register(&btapb.GcRule_MaxNumVersions{})
+	// RegisterName fixes https://github.com/bitly/little_bigtable/issues/24
+	gob.RegisterName("*admin.GcRule_Intersection_", &btapb.GcRule_Intersection_{})
+	gob.RegisterName("*admin.GcRule_MaxNumVersions", &btapb.GcRule_MaxNumVersions{})
+	gob.RegisterName("*admin.GcRule_Union", &btapb.GcRule_Union{})
+	gob.RegisterName("*admin.GcRule_Union_", &btapb.GcRule_Union_{})
+	gob.RegisterName("*admin.GcRule_MaxAge", &btapb.GcRule_MaxAge{})
 }
 
 // applyGC applies the given GC rule to the cells.


### PR DESCRIPTION
Resolves #24 

Fixes an unreleased change in master from #18 that introduced some incompatibility issues with decoding data with gob. Registers the new types with gob using `RegisterName` to maintain compatibility with existing data.


Original discussion in [this PR](https://github.com/bitly/little_bigtable/pull/22)