### PR TITLE
feat: support reverse scan

### DIFF
--- a/bttest/inmem_test.go
+++ b/bttest/inmem_test.go
@@ -1122,6 +1122,82 @@ func TestReadRowsWithlabelTransformer(t *testing.T) {
 	}
 }
 
+func TestReadRowsReversed(t *testing.T) {
+	ctx := context.Background()
+	srv := newTestServer(t)
+	newTbl := btapb.Table{
+		ColumnFamilies: map[string]*btapb.ColumnFamily{
+			"cf": {GcRule: &btapb.GcRule{Rule: &btapb.GcRule_MaxNumVersions{MaxNumVersions: 1}}},
+		},
+	}
+	tbl, err := srv.CreateTable(ctx, &btapb.CreateTableRequest{Parent: "cluster", TableId: "t", Table: &newTbl})
+	if err != nil {
+		t.Fatalf("Creating table: %v", err)
+	}
+	entries := []struct {
+		row   string
+		value []byte
+	}{
+		{"row1", []byte("a")},
+		{"row2", []byte("b")},
+	}
+
+	for _, entry := range entries {
+		req := &btpb.MutateRowRequest{
+			TableName: tbl.Name,
+			RowKey:    []byte(entry.row),
+			Mutations: []*btpb.Mutation{{
+				Mutation: &btpb.Mutation_SetCell_{SetCell: &btpb.Mutation_SetCell{
+					FamilyName:      "cf",
+					ColumnQualifier: []byte("cq"),
+					TimestampMicros: 1000,
+					Value:           entry.value,
+				}},
+			}},
+		}
+		if _, err := srv.MutateRow(ctx, req); err != nil {
+			t.Fatalf("Failed to insert entry %v into server: %v", entry, err)
+		}
+	}
+
+	rrss := new(MockReadRowsServer)
+	rreq := &btpb.ReadRowsRequest{TableName: tbl.Name, Reversed: true}
+	if err := srv.ReadRows(rreq, rrss); err != nil {
+		t.Fatalf("Failed to read rows: %v", err)
+	}
+
+	var gotChunks []*btpb.ReadRowsResponse_CellChunk
+	for _, res := range rrss.responses {
+		gotChunks = append(gotChunks, res.Chunks...)
+	}
+
+	wantChunks := []*btpb.ReadRowsResponse_CellChunk{
+		{
+			RowKey:          []byte("row2"),
+			FamilyName:      &wrappers.StringValue{Value: "cf"},
+			Qualifier:       &wrappers.BytesValue{Value: []byte("cq")},
+			TimestampMicros: 1000,
+			Value:           []byte("b"),
+			RowStatus: &btpb.ReadRowsResponse_CellChunk_CommitRow{
+				CommitRow: true,
+			},
+		},
+		{
+			RowKey:          []byte("row1"),
+			FamilyName:      &wrappers.StringValue{Value: "cf"},
+			Qualifier:       &wrappers.BytesValue{Value: []byte("cq")},
+			TimestampMicros: 1000,
+			Value:           []byte("a"),
+			RowStatus: &btpb.ReadRowsResponse_CellChunk_CommitRow{
+				CommitRow: true,
+			},
+		},
+	}
+	if diff := cmp.Diff(gotChunks, wantChunks, cmp.Comparer(proto.Equal)); diff != "" {
+		t.Fatalf("Response chunks mismatch: got: + want -\n%s", diff)
+	}
+}
+
 func TestCheckAndMutateRowWithoutPredicate(t *testing.T) {
 	s := newTestServer(t)
 	ctx := context.Background()

--- a/bttest/sql_rows.go
+++ b/bttest/sql_rows.go
@@ -101,6 +101,27 @@ func (db *SqlRows) AscendRange(greaterOrEqual, lessThan Item, iterator ItemItera
 	db.query(iterator, "SELECT row_key, families FROM rows_t WHERE parent = ? and table_id = ? and row_key >= ? and row_key < ? ORDER BY row_key ASC", db.parent, db.tableId, ge.key, lt.key)
 }
 
+// Descending order methods for reverse scans
+func (db *SqlRows) Descend(iterator ItemIterator) {
+	db.query(iterator, "SELECT row_key, families FROM rows_t WHERE parent = ? and table_id = ? ORDER BY row_key DESC", db.parent, db.tableId)
+}
+
+func (db *SqlRows) DescendGreaterOrEqual(pivot Item, iterator ItemIterator) {
+	row := pivot.(*row)
+	db.query(iterator, "SELECT row_key, families FROM rows_t WHERE parent = ? and table_id = ? and row_key >= ? ORDER BY row_key DESC", db.parent, db.tableId, row.key)
+}
+
+func (db *SqlRows) DescendLessThan(pivot Item, iterator ItemIterator) {
+	row := pivot.(*row)
+	db.query(iterator, "SELECT row_key, families FROM rows_t WHERE parent = ? and table_id = ? and row_key < ? ORDER BY row_key DESC", db.parent, db.tableId, row.key)
+}
+
+func (db *SqlRows) DescendRange(greaterOrEqual, lessThan Item, iterator ItemIterator) {
+	ge := greaterOrEqual.(*row)
+	lt := lessThan.(*row)
+	db.query(iterator, "SELECT row_key, families FROM rows_t WHERE parent = ? and table_id = ? and row_key >= ? and row_key < ? ORDER BY row_key DESC", db.parent, db.tableId, ge.key, lt.key)
+}
+
 func (db *SqlRows) DeleteAll() {
 	db.mu.Lock()
 	defer db.mu.Unlock()


### PR DESCRIPTION
This adds support for [`bigtable.ReverseScan`](https://pkg.go.dev/cloud.google.com/go/bigtable#ReverseScan) ReadOption matching implementation in googleapis/google-cloud-go#8198

This avoids an `out of order row key, must be strictly decreasing.` error when using the ReverseScan option.