### PR TITLE
Update CMV sql syntax to be safe on all sqlite versions

### DIFF
--- a/bttest/sql_materialized_views.go
+++ b/bttest/sql_materialized_views.go
@@ -56,8 +56,7 @@ func (m *SqlMaterializedViews) Save(name, query string, deletionProtection bool)
 		dp = 1
 	}
 	_, err := m.db.Exec(
-		"INSERT INTO materialized_views_t (name, query, deletion_protection) VALUES (?, ?, ?)"+
-			" ON CONFLICT(name) DO UPDATE SET query=excluded.query, deletion_protection=excluded.deletion_protection",
+		"INSERT OR REPLACE INTO materialized_views_t (name, query, deletion_protection) VALUES (?, ?, ?)",
 		name, query, dp,
 	)
 	if err != nil {


### PR DESCRIPTION
## Description
This PR updates the SQL syntax in the CMV Save functionality to be safe across all versions of SQLite. This was done as the version our testrunners use is an older version that current VMs.

## JIRA
Resolves [SQ-4678](https://puffer.atlassian.net/browse/SQ-4678)

[SQ-4678]: https://puffer.atlassian.net/browse/SQ-4678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ